### PR TITLE
Fixed error in some specific strings and compilation dependencies

### DIFF
--- a/speech_database/CMakeLists.txt
+++ b/speech_database/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${catkin_INCLUDE_DIRS})
 
 ## Declare a cpp executable
 add_executable(speech_database src/speech_database.cpp)
+add_dependencies(speech_database ${catkin_EXPORTED_TARGETS})
 target_link_libraries(speech_database ${catkin_LIBRARIES})
 
 ## Specify libraries to link a library or executable target against

--- a/speech_database/src/speech_database.cpp
+++ b/speech_database/src/speech_database.cpp
@@ -110,7 +110,8 @@ int main(int argc, char** argv) {
   } else {
 	  ROS_DEBUG("json file %s successfully opened", jsonPath.c_str());
   }
-  ROS_INFO("Hello world!");
+  ROS_INFO("Starting speech service!");
+
   // init curl
   curl = curl_easy_init();
   
@@ -142,6 +143,7 @@ int main(int argc, char** argv) {
  */
 void stringCallback(const std_msgs::String msg) {
 	string data = msg.data;
+    ROS_INFO_STREAM("Received request of speech with data \"" << data << "\" of size " << data.length());
 	if(data.length() >  100) {
 		ROS_WARN("The exceeds the maximum length of 100 characters and will not be synthesised.");
 		return;
@@ -164,7 +166,8 @@ void stringCallback(const std_msgs::String msg) {
 		char* str = curl_easy_escape(curl, data.c_str(), 0);
 		urlStream << str;
 		curl_free(str);
-		ROS_INFO(urlStream.str().c_str());
+        
+		ROS_INFO_STREAM("Google Translate's URL: " << urlStream.str());
 		
 		stringstream filenameStream;
 		FILE* file = fopen("/dev/null", "r");	// some existing file


### PR DESCRIPTION
When a string included a space and a word starting by n such as "It is not" an error appeared:` *** %n in writable segment detected ***`

Fixed in the ROS_INFO in line 167, probably due to the c_str() getting confused by the HTML "%20n" codification.